### PR TITLE
Feat: Support scalar comparison of range vectors

### DIFF
--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -235,6 +235,8 @@ func (e *BinaryExpr) Type() ValueType {
 		return ValueTypeScalar
 	} else if e.LHS.Type() == ValueTypeMatrix && e.RHS.Type() == ValueTypeScalar {
 		return ValueTypeMatrix
+	} else if e.LHS.Type() == ValueTypeScalar && e.RHS.Type() == ValueTypeMatrix {
+		return ValueTypeMatrix
 	}
 	return ValueTypeVector
 }

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -233,6 +233,8 @@ func (e *VectorSelector) Type() ValueType { return ValueTypeVector }
 func (e *BinaryExpr) Type() ValueType {
 	if e.LHS.Type() == ValueTypeScalar && e.RHS.Type() == ValueTypeScalar {
 		return ValueTypeScalar
+	} else if e.LHS.Type() == ValueTypeMatrix && e.RHS.Type() == ValueTypeScalar {
+		return ValueTypeMatrix
 	}
 	return ValueTypeVector
 }

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -231,11 +231,12 @@ func (e *StringLiteral) Type() ValueType  { return ValueTypeString }
 func (e *UnaryExpr) Type() ValueType      { return e.Expr.Type() }
 func (e *VectorSelector) Type() ValueType { return ValueTypeVector }
 func (e *BinaryExpr) Type() ValueType {
-	if e.LHS.Type() == ValueTypeScalar && e.RHS.Type() == ValueTypeScalar {
+	lhsType, rhsType := e.LHS.Type(), e.RHS.Type()
+	if lhsType == ValueTypeScalar && rhsType == ValueTypeScalar {
 		return ValueTypeScalar
-	} else if e.LHS.Type() == ValueTypeMatrix && e.RHS.Type() == ValueTypeScalar {
+	} else if lhsType == ValueTypeMatrix && rhsType == ValueTypeScalar {
 		return ValueTypeMatrix
-	} else if e.LHS.Type() == ValueTypeScalar && e.RHS.Type() == ValueTypeMatrix {
+	} else if lhsType == ValueTypeScalar && rhsType == ValueTypeMatrix {
 		return ValueTypeMatrix
 	}
 	return ValueTypeVector

--- a/promql/parser/lex.go
+++ b/promql/parser/lex.go
@@ -90,6 +90,23 @@ func (i ItemType) IsSetOperator() bool {
 	return false
 }
 
+// InverseComparisonOperator returns inverse counterpart of a comparison operator.
+func (i ItemType) InverseComparisonOperator() ItemType {
+	if i.IsComparisonOperator() {
+		switch i {
+		case LTE:
+			return GTE
+		case GTE:
+			return LTE
+		case GTR:
+			return LSS
+		case LSS:
+			return GTR
+		}
+	}
+	return i
+}
+
 type ItemType int
 
 // This is a list of all keywords in PromQL.

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -511,13 +511,14 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 		if !n.Op.IsOperator() {
 			p.addParseErrf(n.PositionRange(), "binary expression does not support operator %q", n.Op)
 		}
-		if lt != ValueTypeScalar && lt != ValueTypeVector {
-			p.addParseErrf(n.LHS.PositionRange(), "binary expression must contain only scalar and instant vector types")
-		}
-		if rt != ValueTypeScalar && rt != ValueTypeVector {
-			p.addParseErrf(n.RHS.PositionRange(), "binary expression must contain only scalar and instant vector types")
-		}
-
+		/*
+			if lt != ValueTypeScalar && lt != ValueTypeVector {
+				p.addParseErrf(n.LHS.PositionRange(), "binary expression must contain only scalar and instant vector types")
+			}
+			if rt != ValueTypeScalar && rt != ValueTypeVector {
+				p.addParseErrf(n.RHS.PositionRange(), "binary expression must contain only scalar and instant vector types")
+			}
+		*/
 		if (lt != ValueTypeVector || rt != ValueTypeVector) && n.VectorMatching != nil {
 			if len(n.VectorMatching.MatchingLabels) > 0 {
 				p.addParseErrf(n.PositionRange(), "vector matching only allowed between instant vectors")

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -511,6 +511,8 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 		if !n.Op.IsOperator() {
 			p.addParseErrf(n.PositionRange(), "binary expression does not support operator %q", n.Op)
 		}
+		// Due to comparison of range vectors with scalars, the following validation check
+		//  needs to be skipped.
 		/*
 			if lt != ValueTypeScalar && lt != ValueTypeVector {
 				p.addParseErrf(n.LHS.PositionRange(), "binary expression must contain only scalar and instant vector types")


### PR DESCRIPTION
## Explanation
Implemented  support for scalar comparison of range vectors in promql, extending binary operation.

## Related Issue:
Closes 10399

## Proposed Changes

- Extended binary operation to support range vectors with scalars
- Enabled comparison to both ways, i.e. when LHS: Range Vector and RHS: Scalar as well as vice-versa
- Also added unit test case for the above mentioned functionality.

### Proof Manifests


<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
