### PR TITLE
Feat: get block by id directly on promtool analyze & get latest block if ID not provided

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -398,22 +398,24 @@ func openBlock(path, blockID string) (*tsdb.DBReadOnly, tsdb.BlockReader, error)
 	if err != nil {
 		return nil, nil, err
 	}
-	blocks, err := db.Blocks()
-	if err != nil {
-		return nil, nil, err
-	}
+
 	var block tsdb.BlockReader
-	switch {
-	case blockID != "":
-		for _, b := range blocks {
-			if b.Meta().ULID.String() == blockID {
-				block = b
-				break
-			}
+
+	if blockID == "" {
+		blockID, err = db.LastBlockID(nil)
+		if err != nil {
+			return nil, nil, err
 		}
-	case len(blocks) > 0:
-		block = blocks[len(blocks)-1]
 	}
+
+	if blockID != "" {
+		b, err := db.Block(nil, filepath.Join(blockID))
+		if err != nil {
+			return nil, nil, err
+		}
+		block = b
+	}
+
 	if block == nil {
 		return nil, nil, fmt.Errorf("block %s not found", blockID)
 	}

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -402,23 +402,18 @@ func openBlock(path, blockID string) (*tsdb.DBReadOnly, tsdb.BlockReader, error)
 	var block tsdb.BlockReader
 
 	if blockID == "" {
-		blockID, err = db.LastBlockID(nil)
+		blockID, err = db.LastBlockID()
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
-	if blockID != "" {
-		b, err := db.Block(nil, filepath.Join(blockID))
-		if err != nil {
-			return nil, nil, err
-		}
-		block = b
+	b, err := db.Block(blockID)
+	if err != nil {
+		return nil, nil, err
 	}
+	block = b
 
-	if block == nil {
-		return nil, nil, fmt.Errorf("block %s not found", blockID)
-	}
 	return db, block, nil
 }
 

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -399,8 +399,6 @@ func openBlock(path, blockID string) (*tsdb.DBReadOnly, tsdb.BlockReader, error)
 		return nil, nil, err
 	}
 
-	var block tsdb.BlockReader
-
 	if blockID == "" {
 		blockID, err = db.LastBlockID()
 		if err != nil {
@@ -412,9 +410,8 @@ func openBlock(path, blockID string) (*tsdb.DBReadOnly, tsdb.BlockReader, error)
 	if err != nil {
 		return nil, nil, err
 	}
-	block = b
 
-	return db, block, nil
+	return db, b, nil
 }
 
 func analyzeBlock(path, blockID string, limit int, runExtended bool) error {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -611,21 +611,18 @@ func (db *DBReadOnly) LastBlockID() (string, error) {
 	max := uint64(0)
 
 	lastBlockID := ""
-	// Walk the blocks directory and find the latest subdirectory
-	for _, e := range entries {
-		// Check if dir is BLOCK dir or not
-		if isBlockDir(e) {
-			dirName := e.Name()
-			ulidObj, err := ulid.ParseStrict(dirName)
-			if err != nil {
-				return "", err
-			}
-			timestamp := ulidObj.Time()
 
-			if timestamp > max {
-				max = timestamp
-				lastBlockID = dirName
-			}
+	for _, e := range entries {
+		// Check if dir is a block dir or not.
+		dirName := e.Name()
+		ulidObj, err := ulid.ParseStrict(dirName)
+		if err != nil {
+			continue // Not a block dir.
+		}
+		timestamp := ulidObj.Time()
+		if timestamp > max {
+			max = timestamp
+			lastBlockID = dirName
 		}
 	}
 
@@ -646,7 +643,7 @@ func (db *DBReadOnly) Block(blockID string) (BlockReader, error) {
 
 	_, err := os.Stat(filepath.Join(db.dir, blockID))
 	if os.IsNotExist(err) {
-		return nil, errors.Errorf("Invalid Block ID %s", blockID)
+		return nil, errors.Errorf("invalid block ID %s", blockID)
 	}
 
 	block, err := OpenBlock(db.logger, filepath.Join(db.dir, blockID), nil)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -2457,24 +2457,21 @@ func TestDBReadOnly(t *testing.T) {
 			require.Equal(t, expBlock.Meta(), blocks[i].Meta(), "block meta mismatch")
 		}
 	})
-	t.Run("analyse-block-id", func(t *testing.T) {
+	t.Run("block", func(t *testing.T) {
 		blockID := expBlock.meta.ULID.String()
-		block, err := dbReadOnly.Block(nil, blockID)
+		block, err := dbReadOnly.Block(blockID)
 		require.NoError(t, err)
 		require.Equal(t, expBlock.Meta(), block.Meta(), "block meta mismatch")
 	})
-	t.Run("invalid-block-id", func(t *testing.T) {
+	t.Run("invalid block ID", func(t *testing.T) {
 		blockID := "01GTDVZZF52NSWB5SXQF0P2PGF"
-		_, err := dbReadOnly.Block(nil, blockID)
+		_, err := dbReadOnly.Block(blockID)
 		require.Error(t, err)
 	})
-	t.Run("analyse-latest-block", func(t *testing.T) {
-		blockID, err := dbReadOnly.LastBlockID(nil)
-		expBlock = expBlocks[2]
+	t.Run("last block ID", func(t *testing.T) {
+		blockID, err := dbReadOnly.LastBlockID()
 		require.NoError(t, err)
-		block, err := dbReadOnly.Block(nil, blockID)
-		require.NoError(t, err)
-		require.Equal(t, expBlock.Meta(), block.Meta(), "block meta mismatch")
+		require.Equal(t, expBlocks[2].Meta().ULID.String(), blockID)
 	})
 	t.Run("querier", func(t *testing.T) {
 		// Open a read only db and ensure that the API returns the same result as the normal DB.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -2384,6 +2384,7 @@ func TestDBReadOnly(t *testing.T) {
 		dbDir     string
 		logger    = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 		expBlocks []*Block
+		expBlock  *Block
 		expSeries map[string][]tsdbutil.Sample
 		expChunks map[string][][]tsdbutil.Sample
 		expDBHash []byte
@@ -2427,6 +2428,7 @@ func TestDBReadOnly(t *testing.T) {
 		require.NoError(t, app.Commit())
 
 		expBlocks = dbWritable.Blocks()
+		expBlock = expBlocks[0]
 		expDbSize, err := fileutil.DirSize(dbWritable.Dir())
 		require.NoError(t, err)
 		require.Greater(t, expDbSize, dbSizeBeforeAppend, "db size didn't increase after an append")
@@ -2455,7 +2457,25 @@ func TestDBReadOnly(t *testing.T) {
 			require.Equal(t, expBlock.Meta(), blocks[i].Meta(), "block meta mismatch")
 		}
 	})
-
+	t.Run("analyse-block-id", func(t *testing.T) {
+		blockID := expBlock.meta.ULID.String()
+		block, err := dbReadOnly.Block(nil, blockID)
+		require.NoError(t, err)
+		require.Equal(t, expBlock.Meta(), block.Meta(), "block meta mismatch")
+	})
+	t.Run("invalid-block-id", func(t *testing.T) {
+		blockID := "01GTDVZZF52NSWB5SXQF0P2PGF"
+		_, err := dbReadOnly.Block(nil, blockID)
+		require.Error(t, err)
+	})
+	t.Run("analyse-latest-block", func(t *testing.T) {
+		blockID, err := dbReadOnly.LastBlockID(nil)
+		expBlock = expBlocks[2]
+		require.NoError(t, err)
+		block, err := dbReadOnly.Block(nil, blockID)
+		require.NoError(t, err)
+		require.Equal(t, expBlock.Meta(), block.Meta(), "block meta mismatch")
+	})
 	t.Run("querier", func(t *testing.T) {
 		// Open a read only db and ensure that the API returns the same result as the normal DB.
 		q, err := dbReadOnly.Querier(context.TODO(), math.MinInt64, math.MaxInt64)


### PR DESCRIPTION
### Explanation
The program currently loads all blocks when a user tries to analyze a block using a BlockID, which can be time-consuming as the block size increases. Additionally, if a BlockID is not provided, the program still retrieves all blocks before analyzing the latest one.

The Block(), LastBlockID(), and lastBlockDirName() functions have been implemented. These functions analyze a block by BlockID. If no BlockID is provided, they analyze the latest block.

### Related PR
PR 11528 Status - Open

### Related Issue 
Closes 10822 
 
### Proposed Changes
_Existing code: `openBlock() `called by `analyzeBlock()` uses `Blocks() `function which returns slice of `BlockReaders`._

`Block()` takes up BlockID and analyses that particular block.
If BlockID is not provided by user then `LastBlockID()` will get the BlockID for last block in the tsdb storage with the help of `lastBlockDirName()`
Unit test case for this feat is implemented.

### Proof Manifests
**CLI Output**

_With BlockID_
``` shell
$ ./promtool tsdb analyze data/ 01GT3F36F6YVGS72BEH580W0S5
Block ID: 01GT3F36F6YVGS72BEH580W0S5
Duration: 17h54m59.934s
Series: 432
Label names: 25
Postings (unique label pairs): 343
Postings entries (total label pairs): 1696

Label pairs most involved in churning:
0 le=0.1
0 call=services
0 __name__=prometheus_sd_file_scan_duration_seconds_sum
0 __name__=prometheus_sd_kubernetes_events_total
0 __name__=go_memstats_frees_total
0 reason=refused
0 __name__=net_conntrack_listener_conn_accepted_total
0 __name__=prometheus_http_request_duration_seconds_bucket
0 code=503
0 revision=66da1d51fd92977df9a9bf4f8c69303b2ba8d88e-modified
0 __name__=prometheus_rule_group_duration_seconds_sum
0 __name__=prometheus_sd_updates_total
0 le=25600
0 __name__=prometheus_target_metadata_cache_entries
0 __name__=prometheus_tsdb_wal_fsync_duration_seconds_sum
0 __name__=process_virtual_memory_max_bytes
0 le=0.2
0 handler=/graph
0 __name__=prometheus_target_interval_length_seconds_count
0 le=10000

Label names most involved in churning:
0 instance
0 slice
0 endpoint
0 name
0 goversion
0 le
0 event
0 interval
0 job
0 quantile
0 version
0 reason
0 listener_name
0 goarch
0 goos
0 handler
0 config
0 scrape_job
0 __name__
0 dialer_name


...

Highest cardinality metric names:
30 prometheus_http_request_duration_seconds_bucket
27 prometheus_http_response_size_bytes_bucket
18 prometheus_sd_kubernetes_events_total
15 prometheus_tsdb_compaction_duration_seconds_bucket
13 prometheus_tsdb_compaction_chunk_samples_bucket
13 prometheus_tsdb_compaction_chunk_size_bytes_bucket
12 prometheus_engine_query_duration_seconds
12 net_conntrack_dialer_conn_failed_total
12 prometheus_tsdb_tombstone_cleanup_seconds_bucket
11 prometheus_tsdb_compaction_chunk_range_seconds_bucket
6 prometheus_sd_consul_rpc_duration_seconds
5 go_gc_duration_seconds
5 prometheus_target_interval_length_seconds
5 prometheus_rule_group_duration_seconds
5 prometheus_target_sync_length_seconds
4 prometheus_engine_query_duration_seconds_count
4 prometheus_engine_query_duration_seconds_sum
3 prometheus_rule_evaluation_duration_seconds
3 net_conntrack_dialer_conn_closed_total
3 promhttp_metric_handler_requests_total
```

_Without BlockID_
```shell
$ ./promtool tsdb analyze
Block ID: 01GT3F36F6YVGS72BEH580W0S5
Duration: 17h54m59.934s
Series: 432
Label names: 25
Postings (unique label pairs): 343
Postings entries (total label pairs): 1696

Label pairs most involved in churning:
0 __name__=prometheus_http_response_size_bytes_bucket
0 __name__=prometheus_sd_consul_rpc_duration_seconds_sum
0 __name__=prometheus_sd_kuma_fetch_duration_seconds_sum
0 __name__=prometheus_tsdb_tombstone_cleanup_seconds_bucket
0 le=512
0 __name__=prometheus_tsdb_head_gc_duration_seconds_count
0 __name__=prometheus_tsdb_head_min_time
0 __name__=go_gc_duration_seconds_sum
0 __name__=go_threads
0 __name__=prometheus_engine_queries_concurrent_max
0 __name__=prometheus_sd_file_scan_duration_seconds_count
0 le=72
0 type=histogram
0 slice=queue_time
0 __name__=prometheus_target_scrapes_sample_out_of_order_total
0 __name__=prometheus_template_text_expansions_total
0 __name__=prometheus_tsdb_head_chunks_created_total
0 __name__=prometheus_tsdb_isolation_low_watermark
0 __name__=prometheus_target_scrape_pool_exceeded_target_limit_total
0 __name__=prometheus_tsdb_compaction_chunk_samples_count

.
.....

Highest cardinality metric names:
30 prometheus_http_request_duration_seconds_bucket
27 prometheus_http_response_size_bytes_bucket
18 prometheus_sd_kubernetes_events_total
15 prometheus_tsdb_compaction_duration_seconds_bucket
13 prometheus_tsdb_compaction_chunk_samples_bucket
13 prometheus_tsdb_compaction_chunk_size_bytes_bucket
12 prometheus_engine_query_duration_seconds
12 net_conntrack_dialer_conn_failed_total
12 prometheus_tsdb_tombstone_cleanup_seconds_bucket
11 prometheus_tsdb_compaction_chunk_range_seconds_bucket
6 prometheus_sd_consul_rpc_duration_seconds
5 go_gc_duration_seconds
5 prometheus_target_interval_length_seconds
5 prometheus_rule_group_duration_seconds
5 prometheus_target_sync_length_seconds
4 prometheus_engine_query_duration_seconds_count
4 prometheus_engine_query_duration_seconds_sum
3 prometheus_rule_evaluation_duration_seconds
3 net_conntrack_dialer_conn_closed_total
3 promhttp_metric_handler_requests_total
```

**Test Case output** 
When BlockID is passed 
```
level=info msg="Found healthy block" mint=10 maxt=12 ulid=01GTBEGMJYRX8PYQ34XH982XEV
level=info msg="Found healthy block" mint=12 maxt=14 ulid=01GTBEGMKJX1YE4D3XZ393Y8WW
level=info msg="Found healthy block" mint=14 maxt=16 ulid=01GTBEGMM14QS037Y0MRZF8SDJ
level=info msg="Replaying on-disk memory mappable chunks if any"
level=info msg="On-disk memory mappable chunks replay completed" duration=2.352µs
level=info msg="Replaying WAL, this may take a while"
level=info msg="WAL segment loaded" segment=0 maxSegment=1
level=info msg="WAL segment loaded" segment=1 maxSegment=1
level=info msg="WAL replay completed" checkpoint_replay_duration=45.93µs wal_replay_duration=970µs wbl_replay_duration=69ns total_replay_duration=1.029182ms
level=info msg="Compactions disabled"
{01GTBEGMJYRX8PYQ34XH982XEV 10 12 {2 1 1 0} {1 [01GTBEGMJYRX8PYQ34XH982XEV] false [] false []} 1}
{01GTBEGMJYRX8PYQ34XH982XEV 10 12 {2 1 1 0} {1 [01GTBEGMJYRX8PYQ34XH982XEV] false [] false []} 1}
```
When BlockID is not passed 
```
level=info msg="Found healthy block" mint=10 maxt=12 ulid=01GTBDCGCGAJ1DXHC25K1NRXFV
level=info msg="Found healthy block" mint=12 maxt=14 ulid=01GTBDCGD4BH4BNQWQBD35Z92M
level=info msg="Found healthy block" mint=14 maxt=16 ulid=01GTBDCGDJ36SDFQAJGAX798MK
level=info msg="Replaying on-disk memory mappable chunks if any"
level=info msg="On-disk memory mappable chunks replay completed" duration=2.856µs
level=info msg="Replaying WAL, this may take a while"
level=info msg="WAL segment loaded" segment=0 maxSegment=1
level=info msg="WAL segment loaded" segment=1 maxSegment=1
level=info msg="WAL replay completed" checkpoint_replay_duration=46.932µs wal_replay_duration=1.251607ms wbl_replay_duration=89ns total_replay_duration=1.315984ms
level=info msg="Compactions disabled"
{01GTBDCGCGAJ1DXHC25K1NRXFV 10 12 {2 1 1 0} {1 [01GTBDCGCGAJ1DXHC25K1NRXFV] false [] false []} 1}
{01GTBDCGCGAJ1DXHC25K1NRXFV 10 12 {2 1 1 0} {1 [01GTBDCGCGAJ1DXHC25K1NRXFV] false [] false []} 1}
```

