### PR TITLE
refactor: markers related to OOO fields for tracking last added chunk (Post-merge cleanup)

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -121,15 +121,6 @@ type Meta struct {
 	// Time range the data covers.
 	// When MaxTime == math.MaxInt64 the chunk is still open and being appended to.
 	MinTime, MaxTime int64
-
-	// OOOLastRef, OOOLastMinTime and OOOLastMaxTime are kept as markers for
-	// overlapping chunks.
-	// These fields point to the last created out of order Chunk (the head) that existed
-	// when Series() was called and was overlapping.
-	// Series() and Chunk() method responses should be consistent for the same
-	// query even if new data is added in between the calls.
-	OOOLastRef                     ChunkRef
-	OOOLastMinTime, OOOLastMaxTime int64
 }
 
 // Iterator iterates over the chunks of a single time series.

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -36,15 +36,16 @@ var _ IndexReader = &OOOHeadIndexReader{}
 // The only methods that change are the ones about getting Series and Postings.
 type OOOHeadIndexReader struct {
 	*headIndexReader // A reference to the headIndexReader so we can reuse as many interface implementation as possible.
+	oooSt            *OOOState
 }
 
-func NewOOOHeadIndexReader(head *Head, mint, maxt int64) *OOOHeadIndexReader {
+func NewOOOHeadIndexReader(head *Head, mint, maxt int64, oooSt *OOOState) *OOOHeadIndexReader {
 	hr := &headIndexReader{
 		head: head,
 		mint: mint,
 		maxt: maxt,
 	}
-	return &OOOHeadIndexReader{hr}
+	return &OOOHeadIndexReader{hr, oooSt}
 }
 
 func (oh *OOOHeadIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
@@ -77,31 +78,28 @@ func (oh *OOOHeadIndexReader) series(ref storage.SeriesRef, builder *labels.Scra
 
 	tmpChks := make([]chunks.Meta, 0, len(s.ooo.oooMmappedChunks))
 
-	// We define these markers to track the last chunk reference while we
-	// fill the chunk meta.
+	// We define this marker to track the last chunk reference while we
+	// fill the OOOState for the current query.
 	// These markers are useful to give consistent responses to repeated queries
 	// even if new chunks that might be overlapping or not are added afterwards.
-	// Also, lastMinT and lastMaxT are initialized to the max int as a sentinel
+	// Also, lastMinT is initialized to the max int as a sentinel
 	// value to know they are unset.
-	var lastChunkRef chunks.ChunkRef
-	lastMinT, lastMaxT := int64(math.MaxInt64), int64(math.MaxInt64)
+	lastMinT := int64(math.MaxInt64)
 
 	addChunk := func(minT, maxT int64, ref chunks.ChunkRef) {
 		// the first time we get called is for the last included chunk.
 		// set the markers accordingly
 		if lastMinT == int64(math.MaxInt64) {
-			lastChunkRef = ref
 			lastMinT = minT
-			lastMaxT = maxT
+			oh.oooSt.OOOLastRef = ref
+			oh.oooSt.OOOLastMinTime = lastMinT
+			oh.oooSt.OOOLastMaxTime = maxT
 		}
 
 		tmpChks = append(tmpChks, chunks.Meta{
-			MinTime:        minT,
-			MaxTime:        maxT,
-			Ref:            ref,
-			OOOLastRef:     lastChunkRef,
-			OOOLastMinTime: lastMinT,
-			OOOLastMaxTime: lastMaxT,
+			MinTime: minT,
+			MaxTime: maxT,
+			Ref:     ref,
 		})
 	}
 
@@ -216,13 +214,15 @@ func (oh *OOOHeadIndexReader) Postings(name string, values ...string) (index.Pos
 type OOOHeadChunkReader struct {
 	head       *Head
 	mint, maxt int64
+	oooSt      *OOOState
 }
 
-func NewOOOHeadChunkReader(head *Head, mint, maxt int64) *OOOHeadChunkReader {
+func NewOOOHeadChunkReader(head *Head, mint, maxt int64, oooSt *OOOState) *OOOHeadChunkReader {
 	return &OOOHeadChunkReader{
-		head: head,
-		mint: mint,
-		maxt: maxt,
+		head:  head,
+		mint:  mint,
+		maxt:  maxt,
+		oooSt: oooSt,
 	}
 }
 
@@ -241,7 +241,7 @@ func (cr OOOHeadChunkReader) Chunk(meta chunks.Meta) (chunkenc.Chunk, error) {
 		s.Unlock()
 		return nil, storage.ErrNotFound
 	}
-	c, err := s.oooMergedChunk(meta, cr.head.chunkDiskMapper, cr.mint, cr.maxt)
+	c, err := s.oooMergedChunk(meta, cr.head.chunkDiskMapper, cr.mint, cr.maxt, cr.oooSt)
 	s.Unlock()
 	if err != nil {
 		return nil, err
@@ -266,6 +266,7 @@ type OOOCompactionHead struct {
 	postings    []storage.SeriesRef
 	chunkRange  int64
 	mint, maxt  int64 // Among all the compactable chunks.
+	oooSt       *OOOState
 }
 
 // NewOOOCompactionHead does the following:
@@ -280,6 +281,7 @@ func NewOOOCompactionHead(head *Head) (*OOOCompactionHead, error) {
 		chunkRange: head.chunkRange.Load(),
 		mint:       math.MaxInt64,
 		maxt:       math.MinInt64,
+		oooSt:      &OOOState{},
 	}
 
 	if head.wbl != nil {
@@ -290,7 +292,7 @@ func NewOOOCompactionHead(head *Head) (*OOOCompactionHead, error) {
 		ch.lastWBLFile = lastWBLFile
 	}
 
-	ch.oooIR = NewOOOHeadIndexReader(head, math.MinInt64, math.MaxInt64)
+	ch.oooIR = NewOOOHeadIndexReader(head, math.MinInt64, math.MaxInt64, ch.oooSt)
 	n, v := index.AllPostingsKey()
 
 	// TODO: verify this gets only ooo samples.
@@ -349,7 +351,7 @@ func (ch *OOOCompactionHead) Index() (IndexReader, error) {
 }
 
 func (ch *OOOCompactionHead) Chunks() (ChunkReader, error) {
-	return NewOOOHeadChunkReader(ch.oooIR.head, ch.oooIR.mint, ch.oooIR.maxt), nil
+	return NewOOOHeadChunkReader(ch.oooIR.head, ch.oooIR.mint, ch.oooIR.maxt, ch.oooSt), nil
 }
 
 func (ch *OOOCompactionHead) Tombstones() (tombstones.Reader, error) {
@@ -375,12 +377,13 @@ func (ch *OOOCompactionHead) Meta() BlockMeta {
 // Only the method of BlockReader interface are valid for the cloned OOOCompactionHead.
 func (ch *OOOCompactionHead) CloneForTimeRange(mint, maxt int64) *OOOCompactionHead {
 	return &OOOCompactionHead{
-		oooIR:       NewOOOHeadIndexReader(ch.oooIR.head, mint, maxt),
+		oooIR:       NewOOOHeadIndexReader(ch.oooIR.head, mint, maxt, ch.oooSt),
 		lastMmapRef: ch.lastMmapRef,
 		postings:    ch.postings,
 		chunkRange:  ch.chunkRange,
 		mint:        ch.mint,
 		maxt:        ch.maxt,
+		oooSt:       ch.oooSt,
 	}
 }
 
@@ -392,11 +395,12 @@ func (ch *OOOCompactionHead) LastMmapRef() chunks.ChunkDiskMapperRef { return ch
 func (ch *OOOCompactionHead) LastWBLFile() int                       { return ch.lastWBLFile }
 
 type OOOCompactionHeadIndexReader struct {
-	ch *OOOCompactionHead
+	ch    *OOOCompactionHead
+	oooSt *OOOState
 }
 
 func NewOOOCompactionHeadIndexReader(ch *OOOCompactionHead) IndexReader {
-	return &OOOCompactionHeadIndexReader{ch: ch}
+	return &OOOCompactionHeadIndexReader{ch: ch, oooSt: ch.oooSt}
 }
 
 func (ir *OOOCompactionHeadIndexReader) Symbols() index.StringIter {


### PR DESCRIPTION
## Explanation
Refactored markers related to OOO fields from chunks.Meta as it is only needed in OOO head. 

## Related Issue
Closes 11837

## Proposed Changes
Upon investigating, it is found to be mainly used by `Series()` and `Chunk()` methods of OOO Head readers to track the last added chunk. Moving these markers (`OOOLastRef`, `OOOLastMinTime`, `OOOLastMaxTime`) from `chunks.Meta` struct to new `OOOState` struct and include this struct in `OOORangeHead` & `OOOCompactionHead` for better handling of OOO related fields. This solution will track these only during the life cycle of the query.
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
